### PR TITLE
Allow Authorization header in CORS policy

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs21/OpenAPI2SpringBoot.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs21/OpenAPI2SpringBoot.java
@@ -57,7 +57,7 @@ public class OpenAPI2SpringBoot implements CommandLineRunner {
                 registry.addMapping("/**")
                         .allowedOrigins("*")
                         .allowedMethods("*")
-                        .allowedHeaders("Content-Type");
+                        .allowedHeaders("Content-Type", "Authorization");
             }
         };
     }


### PR DESCRIPTION
Add the "Authorization" header to the allowed headers in the CORS policy. We need this so the server accepts requests with the token in the header.﻿
