### PR TITLE
Fix login persistence and token refresh in production

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs21/controller/UsersApiController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs21/controller/UsersApiController.java
@@ -81,11 +81,7 @@ public class UsersApiController implements UsersApi {
                 //call method to save or update user in database
                 userLoginPostDto = userService.loginOrRegisterUser(token.getPayload(), refreshToken);
                 //create cookie to hold refresh token
-                refreshTokenCookie = ResponseCookie.from("refresh_token", refreshToken)
-                        .httpOnly(true)
-                        .maxAge(SecurityConstants.REFRESH_EXPIRATION_TIME / 1000) //convert expiry time from ms to sec
-                        .build();
-
+                refreshTokenCookie = this.buildRefreshTokenCookie(refreshToken);
             }
             else {
                 throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid token");
@@ -160,10 +156,7 @@ public class UsersApiController implements UsersApi {
         userLoginPostDto.setAccessTokenExpiry(accessTokenExpiry.toInstant().atOffset(ZoneOffset.ofHours(2)));
         userLoginPostDto.setIsNewUser(Boolean.FALSE);
         //create cookie to hold refresh token
-        newRefreshTokenCookie = ResponseCookie.from("refresh_token", newRefreshToken)
-                .httpOnly(true)
-                .maxAge(SecurityConstants.REFRESH_EXPIRATION_TIME / 1000) //convert expiry time from ms to sec
-                .build();
+        newRefreshTokenCookie = this.buildRefreshTokenCookie(newRefreshToken);
 
         return ResponseEntity
                 .ok()
@@ -286,5 +279,14 @@ public class UsersApiController implements UsersApi {
         tagService.addTag(tagToAdd);
 
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    private ResponseCookie buildRefreshTokenCookie(String refreshToken) {
+        return ResponseCookie.from("refresh_token", refreshToken)
+                             .httpOnly(true)
+                             .secure(true)
+                             .sameSite("None")
+                             .maxAge(SecurityConstants.REFRESH_EXPIRATION_TIME / 1000) //convert expiry time from ms to sec
+                             .build();
     }
 }


### PR DESCRIPTION
## Problem

So far, when refreshing the page in the production environment, the client was always redirected to the login page and had to authenticate again. Because we need to re-establish the automatic.
Reloading the page triggered a token refresh since in this case the interval to refresh the token in the background is re-started so it doesn't get lost by the page reload.
Due to some misconfiguration of the refresh token cookie for the production environment, this caused a `400 Bad Request` response as the refresh token cookie was not transmitted.
In the error case, the client-side code deletes the access token and logs the user out b/c it is assumed that something with the authentication is wrong.

## Fix

The cookie is now set to `SameSite=None` so it is also transmitted on API requests to the server which lives on a different domain.
Since this policy requires the `Secure` attribute, this was also added (`Secure` is ignored on localhost, so it still works there).
As a small refactoring, the redundant code in the `UsersApiController` was extracted into a separate private method.﻿
